### PR TITLE
Set DB_HOSTNAME to "db"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       TZ: Europe/Berlin
       # needs to be at least 6 characters long
       # VSP_WEB_PASSWORD:
+      DB_HOSTNAME: db
       DB_NAME: vsp
       # use the same value as for MYSQL_USER
       DB_USERNAME:


### PR DESCRIPTION
"host.docker.internal" does not resolve on docker-20.10.4-1.amzn2.x86_64 running on Amazon Linux 2 AMI nor on docker-ce-20.10.7-3.el7.x86_64 on CentOS 7.9.2009. However, the service "db" should always resolve correctly through Docker's native DNS ensuring the connection to the DB always succeeds regardless of platform. 

Example of Issue:
root@1f262848f947:/vsp# curl host.docker.internal
curl: (6) Could not resolve host: host.docker.internal
root@1f262848f947:/vsp# curl db
curl: (7) Failed to connect to db port 80: Connection refused
root@1f262848f947:/vsp#