### PR TITLE
fix search-by-name

### DIFF
--- a/pub/themes/bismarck/index.php
+++ b/pub/themes/bismarck/index.php
@@ -142,15 +142,20 @@ function drawPlayersList()
     if ($_POST['search_by']=='name')
     {
       //echo $search_txt."<BR>";
-      $search_txt=preg_replace("/(.)/e", "'(`#[0-9a-fA-F]{6})*'.preg_quote(preg_quote('\\1','\''),'\'')", $search_txt);
-      //echo $search_txt."<BR>";
+      $search_txt = preg_replace_callback(
+        "/(.)/",
+        function ($matches) {
+            return '(`#[0-9a-fA-F]{6})*' . preg_quote(preg_quote($matches[1], '\''), '\'');
+        },
+        $search_txt
+    );      //echo $search_txt."<BR>";
 
       $sql="select distinct PP.playerID as playerID,playerName,skill as skill,kills,deaths,kill_streak,death_streak,games,countryCode
               from {$GLOBALS['cfg']['db']['table_prefix']}playerprofile as PP,{$GLOBALS['cfg']['db']['table_prefix']}playerdata_total as PD
               where dataName='alias' 
                 AND dataValue REGEXP '$search_txt'
                 AND PP.playerID=PD.playerID
-                ".($GLOBALS['excluded_players'] ? "and pp.playerID not in {$GLOBALS['excluded_players']}" : "")."
+                ".($GLOBALS['excluded_players'] ? "and PP.playerID not in {$GLOBALS['excluded_players']}" : "")."
               order by {$GLOBALS['sort']} {$GLOBALS['order']}
            ";
       //echo $sql;


### PR DESCRIPTION
There were 2 problems that broke this feature.

1.  the sql referred to `pp` instead of `PP`. This is the alias used to refer to the `playerprofile` table
2. the regex used to add sql regex to the search text attempted to use `/e ` which is no longer supported.