### PR TITLE
replace ereg with preg_match to fix parsing ftp file list output

### DIFF
--- a/vutil.php
+++ b/vutil.php
@@ -5,8 +5,8 @@ function parseFileListing($fileLines)
 {
     foreach ($fileLines as $line) {
         if (
-            ereg(
-                "([-dl][rwxst-]+).* ([0-9]*) ([a-zA-Z0-9]+).* ([a-zA-Z0-9]+).* ([0-9]*) ([a-zA-Z]+[0-9: ]*[0-9])[ ]+(([0-9]{2}:[0-9]{2})|[0-9]{4}) (.+)",
+            preg_match(
+                "/([-dl][rwxst-]+).* ([0-9]*) ([a-zA-Z0-9]+).* ([a-zA-Z0-9]+).* ([0-9]*) ([a-zA-Z]+[0-9: ]*[0-9])[ ]+(([0-9]{2}:[0-9]{2})|[0-9]{4}) (.+)/",
                 $line,
                 $matches
             )


### PR DESCRIPTION
`ereg` is no longer supported. Replaced it with `preg_match`